### PR TITLE
500 internal server error fix for some usernames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .vercel
+.venv

--- a/modules/scrap.py
+++ b/modules/scrap.py
@@ -25,7 +25,7 @@ class scrap():
             return result
 
         def extract_details(soup):
-            basic_details_by_index = ["institution", "languagesUsed"]
+            basic_details_by_index = ["institution", "languagesUsed", "campusAmbassador"]
             coding_scores_by_index = ["codingScore", "totalProblemsSolved", "monthlyCodingScore", "articlesPublished"]
             basic_details = soup.find_all("div", class_ = "basic_details_data")
             coding_scores = soup.find_all("span", class_ = "score_card_value")


### PR DESCRIPTION
## Issue

while scraping the user details,

```python
basic_details_by_index = ["institution", "languagesUsed"]
basic_details = soup.find_all("div", class_ = "basic_details_data")
response["basic_details"] = extract_text_from_elements(basic_details, basic_details_by_index)
```  

for some users having campus ambasadors that details also scraped out in `basic_details`, hence length of list becomes 3 so that index is not available in  `basic_details_by_index`, thus an index out of bound error comes.

## Fix

Just simply handle that also.

```python
basic_details_by_index = ["institution", "languagesUsed", "campusAmbassador"]
```